### PR TITLE
Fix action_on_callback documentation

### DIFF
--- a/docs/power_types/action_on_callback.md
+++ b/docs/power_types/action_on_callback.md
@@ -1,6 +1,6 @@
 ---
 title: Action On Callback (Power Type)
-date: 2021-04-04
+date: 2021-05-25
 ---
 # Action On Callback
 
@@ -14,12 +14,12 @@ Type ID: `origins:action_on_callback`
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`entity_action_chosen` | [Entity Action](../entity_actions.md) | _optional_ | If set, this action will be executed on the player when the power is gained.
+`entity_action_chosen` | [Entity Action](../entity_actions.md) | _optional_ | If set, this action will be executed on the player when the player chooses their origin on the last layer through the menu - by using the Orb of Origin or missing an origin or joining for the first time - if the power was gained from any of the layers.
 `execute_chosen_when_orb` | [Boolean](../data_types/boolean.md) | true | When this is false, the `entity_action_chosen` will not be executed when the player changes their origin with an orb, but only when the player chooses an origin for the first time or their origin was reset to `origins:empty` via a command.
 `entity_action_lost` | [Entity Action](../entity_actions.md) | _optional_ | If set, this action will be executed on the player when the power is lost.
-`entity_action_added` | [Entity Action](../entity_actions.md) | _optional_ | If set, this action will be executed on the player when the power is added.
-`entity_action_removed` | [Entity Action](../entity_actions.md) | _optional_ | If set, this action will be executed on the player when the power is removed.
-`entity_action_respawned` | [Entity Action](../entity_actions.md) | _optional_ | If set, this action will be executed on the player right after the player respawns.
+`entity_action_added` | [Entity Action](../entity_actions.md) | _optional_ | If set, this action will be executed on the player when the power is added. Joining a world adds each power back.
+`entity_action_removed` | [Entity Action](../entity_actions.md) | _optional_ | If set, this action will be executed on the player when the power is removed and right after the player respawns. Leaving a world removes each power.
+`entity_action_respawned` | [Entity Action](../entity_actions.md) | _optional_ | If set, this action will be executed on the player right after the player respawns, after the `entity_action_removed`.
 
 ### Example
 
@@ -31,7 +31,7 @@ Field  | Type | Default | Description
     	"command": "team join TheNetherBoys @s",
     	"permission_level": 4
   	},
-  	"entity_action_removed": {
+  	"entity_action_lost": {
     	"type": "origins:execute_command",
     	"command": "team leave @s",
     	"permission_level": 4


### PR DESCRIPTION
I didn't remove "or their origin was reset to `origins:empty` via a command" because I believe the fact it's false is unintended behavior, see issue [#307](https://github.com/apace100/origins-fabric/issues/307) on the mod's repo.

```
Y or N is whether `execute_chosen_when_orb` is true or not
The tests were made using origin classes which show behavior related to layers

- Created a new world
- Chose callback origin on origin layer
-> Y entity_action_added
-> N entity_action_added
- Validated last layer
-> Y entity_action_chosen
-> N entity_action_chosen
- /origin set @s origins:origin origins:human
-> Y entity_action_removed
-> Y entity_action_lost
-> N entity_action_removed
-> N entity_action_lost
- /origin set @s origins:origin <callback origin>
-> Y entity_action_added
-> N entity_action_added
- /origin set @s origins:origin origins:human
-> Y entity_action_removed
-> Y entity_action_lost
-> N entity_action_removed
-> N entity_action_lost
- /origin set @s origins:origin <callback origin>
-> Y entity_action_added
-> N entity_action_added
- /origin set @s origins:origin origins:empty
-> Y entity_action_removed
-> Y entity_action_lost
-> N entity_action_removed
-> N entity_action_lost
- /origin set @s origins:origin <callback origin>
-> Y entity_action_added
-> N entity_action_added
- Orb of Origin (on click)
-> Y entity_action_removed
-> Y entity_action_lost
-> N entity_action_removed
-> N entity_action_lost
- Orb of Origin (on selecting the callback on the origin layer)
-> Y entity_action_added
-> N entity_action_added
- Orb of Origin (on validating the last layer)
-> Y entity_action_chosen

- Created a new world
- Chose human on origin layer and chose last layer
- /origin set @s origins:origin <callback origin>
-> Y entity_action_added
-> N entity_action_added
- Orb of Origin (on click)
-> Y entity_action_removed
-> Y entity_action_lost
-> N entity_action_removed
-> N entity_action_lost
- Orb of Origin (on selecting the callback origin on the origin layer)
-> Y entity_action_added
-> N entity_action_added
- Orb of Origin (on validating the last layer)
-> Y entity_action_chosen

- Created a new world
- Chose human on origin layer and validated last layer
- Orb of Origin (click)
- Orb of Origin (on selecting the callback origin on the origin layer)
-> Y entity_action_added
-> N entity_action_added
- Orb of Origin (on validating the last layer)
-> Y entity_action_chosen

- Created a new world
- Chose callback origin on origin layer
-> Y entity_action_added
-> N entity_action_added
- Validated last layer
-> Y entity_action_chosen
-> N entity_action_chosen
- Quit the world
-> Y entity_action_removed
-> N entity_action_removed
- Rejoined the world
-> Y entity_action_added
-> N entity_action_added
- /origin set @s origins:origin origins:empty
-> Y entity_action_removed
-> Y entity_action_lost
-> N entity_action_removed
-> N entity_action_lost
- /origin set @s origins-classes:class origins:empty
- Orb of Origin (click)
- Orb of Origin (on selecting the callback origin on the origin layer)
-> Y entity_action_added
-> N entity_action_added
- Orb of Origin (on validating the last layer)
-> Y entity_action_chosen
- Pressed show origin keybind
- Clicked choose
- Chose callback origin
-> Y entity_action_added
-> N entity_action_added
- Pressed show origin keybind
- Switched to other layer
- Clicked choose
- Chose nitwit
-> Y entity_action_chosen
- /origin set @s origins:origin origins:empty
-> Y entity_action_removed
-> Y entity_action_lost
-> N entity_action_removed
-> N entity_action_lost
- /origin set @s origins-classes:class origins:empty
- Quit and rejoined the world
- Chose the callback origin on the origin layer
-> Y entity_action_added
-> N entity_action_added
- Validated last layer
-> Y entity_action_chosen
- /kill
- Respawned
-> Y entity_action_removed
-> N entity_action_removed
-> Y entity_action_respawned
-> N entity_action_respawned
- /kill
- Quit to title (don't respawn)
-> Y entity_action_removed
-> N entity_action_removed
- Joined the world back
-> Y entity_action_added
-> N entity_action_added
- Respawned
-> Y entity_action_removed
-> N entity_action_removed
-> Y entity_action_respawned
-> N entity_action_respawned
```