### PR TITLE
Update Gamepedia wiki links

### DIFF
--- a/docs/guides/data/define_origin.md
+++ b/docs/guides/data/define_origin.md
@@ -5,7 +5,7 @@ date: 2021-05-02
 
 # Defining an Origin in JSON
 
-Origins are defined in JSON files. Let's use these to create a fictional new origin, a _Supermorph_, for our [Data Pack](https://minecraft.gamepedia.com/Data_Pack) which we call _OriginSuperPack_. We'd like this Origin to be a bit overpowered: Metamorphs are immune to fire, have Elytra Flight and can teleport with ender pearls. Their only drawback is that they need a bed at a high altitude, just like Avians. This would be a JSON file which would accomplish that:
+Origins are defined in JSON files. Let's use these to create a fictional new origin, a _Supermorph_, for our [Data Pack](https://minecraft.wiki/w/Data_Pack) which we call _OriginSuperPack_. We'd like this Origin to be a bit overpowered: Metamorphs are immune to fire, have Elytra Flight and can teleport with ender pearls. Their only drawback is that they need a bed at a high altitude, just like Avians. This would be a JSON file which would accomplish that:
 
 ```json
 {
@@ -40,7 +40,7 @@ The new origin still needs to be added to the origin layer. Layers are the way t
 
 Now, our newly created _Supermorph_ origin should show up, along with a nice slimeball icon, in the list.
 
-However, the origin still doesn't display a correct name or description. One way to fix that is by adding a [Resource Pack](https://minecraft.gamepedia.com/Resource_Pack) as well, with a translation for the language you're playing in (probably `en_us.json`):
+However, the origin still doesn't display a correct name or description. One way to fix that is by adding a [Resource Pack](https://minecraft.wiki/w/Resource_Pack) as well, with a translation for the language you're playing in (probably `en_us.json`):
 ```json
 {
 	"origin.originsuperpack.supermorph.name": "Supermorph",

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,6 @@ Visit [CurseForge](https://www.curseforge.com/minecraft/mc-mods/origins) or [Mod
 ## Helpful links
 
 * [Example data packs](https://github.com/apace100/origins-example-packs)
-* [Minecraft Wiki: Data Pack](https://minecraft.gamepedia.com/Data_Pack)
-* [Minecraft Wiki: Creating a data pack](https://minecraft.gamepedia.com/Tutorials/Creating_a_data_pack)
+* [Minecraft Wiki: Data Pack](https://minecraft.wiki/w/Data_Pack)
+* [Minecraft Wiki: Creating a data pack](https://minecraft.wiki/w/Tutorials/Creating_a_data_pack)
 * [Video Tutorial for creating custom origins with data packs by CandyCaneCazoo](https://www.youtube.com/watch?v=jId0Fw4w2PQ)

--- a/docs/types/data_types/crafting_recipe.md
+++ b/docs/types/data_types/crafting_recipe.md
@@ -7,7 +7,7 @@ date: 2021-04-04
 
 [Data Type](../data_types.md)
 
-An [Object](object.md) specifying a shapeless or shaped crafting recipe. For some more information, view [the page on recipes on the MC wiki](https://minecraft.gamepedia.com/Recipe).
+An [Object](object.md) specifying a shapeless or shaped crafting recipe. For some more information, view [the page on recipes on the MC wiki](https://minecraft.wiki/w/Recipe).
 
 
 ### Fields (both types)

--- a/docs/types/entity_condition_types/predicate.md
+++ b/docs/types/entity_condition_types/predicate.md
@@ -7,7 +7,7 @@ date: 2021-04-04
 
 [Entity Condition Type](../entity_condition_types.md)
 
-Checks whether the entity fulfills a specified [Predicate](https://minecraft.gamepedia.com/Predicate).
+Checks whether the entity fulfills a specified [Predicate](https://minecraft.wiki/w/Predicate).
 
 Type ID: `origins:predicate`
 


### PR DESCRIPTION
This PR updates all Gamepedia, owned by Fandom, URLs accordingly.