### PR TITLE
`origins:set_size` field name correction.

### DIFF
--- a/docs/types/entity_condition_types/set_size.md
+++ b/docs/types/entity_condition_types/set_size.md
@@ -19,7 +19,7 @@ Field | Type | Default | Description
 ------|------|---------|------------
 `set` | [Identifier](../data_types/identifier.md) | | The ID of the power.
 `comparison` | [Comparison](../data_types/comparison.md) | | Determines how the amount of entities stored in the power will be compared to the specified value.
-`value` | [Integer](../data_types/integer.md) | | The specified value to compare the amount of entities stored in the power to.
+`compare_to` | [Integer](../data_types/integer.md) | | The specified value to compare the amount of entities stored in the power to.
 
 
 ###	Examples


### PR DESCRIPTION
- Changed field `value` to `compare_to` in entity condition `origins:set_size`